### PR TITLE
Add mka support

### DIFF
--- a/qml/lib/FolderSelector.qml
+++ b/qml/lib/FolderSelector.qml
@@ -307,7 +307,7 @@ Dialog {
             FolderListModel {
                 id: folderModel
                 showOnlyReadable: true
-                nameFilters: getFileSuffixesCaseInsensitive(["mp3", "m4a", "m4b", "flac", "ogg", "wav", "opus", "aac"])
+                nameFilters: getFileSuffixesCaseInsensitive(["mp3", "m4a", "m4b", "flac", "ogg", "wav", "opus", "aac", "mka"])
                 property int useableFiles: 0
                 property int lastCount: 0
                 folder: appstate.lastDirectory


### PR DESCRIPTION
I had some problems with very large audio books from Audible. When I put them into a Matroska container it worked without problems. Gstreamer can handle Matroska containers. Tested with Talefish on a Jolla Phone.